### PR TITLE
Feat: validate webhook and only return validate results.

### DIFF
--- a/Ungrabber/utils.py
+++ b/Ungrabber/utils.py
@@ -21,300 +21,338 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
-
-from contextlib import redirect_stderr
-import re
-from Crypto.Cipher import AES
-import xdis.codetype
-from typing import *
-from . import regs
-from types import *
-import functools
+import ast
 import base64
 import codecs
-import struct
-import lzma
-import xdis
-import ast
-import sys
 import io
+import lzma
+import struct
+from asyncio import gather, run
+from types import ModuleType
+from typing import List
+
+import xdis
+import xdis.codetype
+from Crypto.Cipher import AES
+from httpx import AsyncClient, RequestError
+
+from . import regs
 
 LZMASign = b'\xFD\x37\x7A\x58\x5A\x00'
 moduleStartByte = (b'\xE3', b'\x63')
 
 versions = {
-  (50823, 50823): (2, 0),
-  (60202, 60202): (2, 1),
-  (60717, 60717): (2, 2),
-  (62011, 62021): (2, 3),
-  (62041, 62061): (2, 4),
-  (62071, 62131): (2, 5),
-  (62151, 62161): (2, 6),
-  (62171, 62211): (2, 7),
-  (3000, 3131): (3, 0),
-  (3141, 3151): (3, 1),
-  (3160, 3180): (3, 2), # Supported
-  (3190, 3230): (3, 3), # Supported
-  (3250, 3310): (3, 4), # Supported
-  (3320, 3351): (3, 5), # Supported
-  (3360, 3379): (3, 6), # Supported
-  (3390, 3399): (3, 7), # Supported
-  (3400, 3419): (3, 8), # Supported
-  (3420, 3429): (3, 9), # Supported
-  (3430, 3449): (3, 10), # Supported
-  (3450, 3499): (3, 11), # Supported
-  (3500, 3549): (3, 12), # Supported
-  (3550, 3599): (3, 13), # Supported
-  (3600, 3649): (3, 14), # Supported
-  (3650, 3699): (3, 15),
-  
+    (50823, 50823): (2, 0),
+    (60202, 60202): (2, 1),
+    (60717, 60717): (2, 2),
+    (62011, 62021): (2, 3),
+    (62041, 62061): (2, 4),
+    (62071, 62131): (2, 5),
+    (62151, 62161): (2, 6),
+    (62171, 62211): (2, 7),
+    (3000, 3131): (3, 0),
+    (3141, 3151): (3, 1),
+    (3160, 3180): (3, 2),  # Supported
+    (3190, 3230): (3, 3),  # Supported
+    (3250, 3310): (3, 4),  # Supported
+    (3320, 3351): (3, 5),  # Supported
+    (3360, 3379): (3, 6),  # Supported
+    (3390, 3399): (3, 7),  # Supported
+    (3400, 3419): (3, 8),  # Supported
+    (3420, 3429): (3, 9),  # Supported
+    (3430, 3449): (3, 10),  # Supported
+    (3450, 3499): (3, 11),  # Supported
+    (3500, 3549): (3, 12),  # Supported
+    (3550, 3599): (3, 13),  # Supported
+    (3600, 3649): (3, 14),  # Supported
+    (3650, 3699): (3, 15),
+
 }
-PY310 = b'\x6F\x0D\x0D\x0A'+b'\00'*12
-PY311 = b'\xA7\x0D\x0D'+b'\x00'*13
-PY312 = b'\xCB\x0D\x0D\x0A'+b'\00'*12
-PY313 = b'\xF3\x0D'+b'\00'*14
-
-
+PY310 = b'\x6F\x0D\x0D\x0A' + b'\00' * 12
+PY311 = b'\xA7\x0D\x0D' + b'\x00' * 13
+PY312 = b'\xCB\x0D\x0D\x0A' + b'\00' * 12
+PY313 = b'\xF3\x0D' + b'\00' * 14
 
 CODE_REF = b'\xE3'
-CODE = b'\x63' # CODE_REF & ~128
+CODE = b'\x63'  # CODE_REF & ~128
+
 
 def magic_to_int(magic: bytes) -> int:
-  return struct.unpack("<Hcc", magic)[0]
+    return struct.unpack("<Hcc", magic)[0]
+
 
 def get_version_from_magics(magicBytes: bytes) -> tuple[int, int] | None:
-  magicInt = magic_to_int(magicBytes)
-  for i, v in versions.items():
-    if magicInt >= i[0] and magicInt <= i[1]:
-      return v
-  return None
+    magicInt = magic_to_int(magicBytes)
+    for i, v in versions.items():
+        if magicInt >= i[0] and magicInt <= i[1]:
+            return v
+    return None
+
 
 def setHeader(pyc: bytes, header: bytes) -> bytes:
-  """
-  Set Given Header To The Pyc File Safely
+    """
+    Set Given Header To The Pyc File Safely
 
-  Args:
-      pyc (bytes): The Target Pyc
-      header (bytes): The Header To Set
-      
+    Args:
+        pyc (bytes): The Target Pyc
+        header (bytes): The Header To Set
 
-  Returns:
-      bytes: The Pyc With Modified Header
-  """
-  if pyc.startswith((CODE, CODE_REF)):
-    return header + pyc
-  
-  return header + pyc[16:]
+
+    Returns:
+        bytes: The Pyc With Modified Header
+    """
+    if pyc.startswith((CODE, CODE_REF)):
+        return header + pyc
+
+    return header + pyc[16:]
 
 
 def isValidHeader(pyc: bytes) -> bool:
-  """
-  Check if a pyc header is valid and supported
+    """
+    Check if a pyc header is valid and supported
 
-  Args:
-      pyc (bytes): The pyc to check
+    Args:
+        pyc (bytes): The pyc to check
 
-  Returns:
-      bool: True if header is valid
-  """
-  
-  return pyc.startswith((PY310[2:], PY311[2:], PY312[2:], PY313[2:]))
+    Returns:
+        bool: True if header is valid
+    """
+
+    return pyc.startswith((PY310[2:], PY311[2:], PY312[2:], PY313[2:]))
+
 
 def getHeader(pymin: int) -> bytes:
-  """
-  This function give you the pyc header of the given python version
+    """
+    This function give you the pyc header of the given python version
 
-  Args:
-      pymin (int): `The python min version`:
-      ```
-      11 = 3.11 , 12 = 3.12
-      ```
-  Returns:
-      bytes: `The pyc header`
-  """
+    Args:
+        pymin (int): `The python min version`:
+        ```
+        11 = 3.11 , 12 = 3.12
+        ```
+    Returns:
+        bytes: `The pyc header`
+    """
 
-  match pymin:
-    case 10:
-      return PY310
-    case 11:
-      return PY311
-    case 12:
-      return PY312
-    case 13:
-      return PY313
-    case _:
-      raise Exception(f'Unsupported version given to function: getHeader')
-  
+    match pymin:
+        case 10:
+            return PY310
+        case 11:
+            return PY311
+        case 12:
+            return PY312
+        case 13:
+            return PY313
+        case _:
+            raise Exception(f'Unsupported version given to function: getHeader')
+
 
 def getWebhooks(content) -> list:
-  """
-  Return a list of Plain webhooks/B64 Encoded webhoook/C2 found in a strings
+    """
+    Return a list of Plain webhooks/B64 Encoded webhoook/C2 found in a strings
 
-  Args:
-      content (str): `Text containing a webhook (plain/b64 webhook)`
+    Args:
+        content (str): `Text containing a webhook (plain/b64 webhook)`
 
-  Returns:
-      list: `List of webhook found (plain)`
-  """
-  
-  content = str(content)
-  
-  encoded = sum([
-    regs.DiscordB64Webhook.findall(content),
-    regs.CanaryB64Webhook.findall(content),
-    regs.PTBB64Webhook.findall(content),
-    regs.DiscordAppB64Webhook.findall(content),
-  ], [])
-  founds = [base64.b64decode(webhook) for webhook in encoded]
-    
-  founds.extend(regs.DiscordWebhook.findall(content))
-  return founds 
+    Returns:
+        list: `List of webhook found (plain)`
+    """
+
+    content = str(content)
+
+    encoded = sum([
+        regs.DiscordB64Webhook.findall(content),
+        regs.CanaryB64Webhook.findall(content),
+        regs.PTBB64Webhook.findall(content),
+        regs.DiscordAppB64Webhook.findall(content),
+    ], [])
+    founds = [base64.b64decode(webhook).decode('utf-8', errors='ignore') for webhook in encoded]
+
+    founds.extend(regs.DiscordWebhook.findall(content))
+    return _validate_webhooks(founds)
+
+
+def _validate_webhooks(founds: List[str]) -> List[str]:
+    """
+      Validate Discord webhooks and remove invalid ones
+    Args:
+      founds: list of string.
+
+    Returns:
+      list of valid webhooks.
+
+    """
+
+    async def validate_webhook_and_return_url(webhook: str) -> str:
+        try:
+            async with AsyncClient() as client:
+                response = await client.get(webhook)
+                return webhook if response.status_code == 200 else ''
+        except RequestError:
+            return ''
+
+    async def _validate_worker() -> List[str]:
+        tasks = []
+        for webhook in founds:
+            tasks.append(validate_webhook_and_return_url(webhook))
+        return await gather(*tasks)
+
+    return [url for url in run(_validate_worker()) if url]
+
 
 # I use this function to optimize code.
 # @functools.lru_cache(maxsize=5) (disabled due to problem with blank)
 def walk_cache(code: str):
-  return ast.walk(ast.parse(code))
+    return ast.walk(ast.parse(code))
+
 
 def getVar(code: str, var: str):
-  """
-  Internal Use Function
-  """
-  for node in walk_cache(code):
-    if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == var for target in node.targets):
-      return node.value
+    """
+    Internal Use Function
+    """
+    for node in walk_cache(code):
+        if isinstance(node, ast.Assign) and any(
+                isinstance(target, ast.Name) and target.id == var for target in node.targets):
+            return node.value
 
 
 def getVarConst(code: str, var: str) -> bool:
-  """
-  Get an Constant value in a code from name
+    """
+    Get an Constant value in a code from name
 
-  Args:
-      code (str): `The code to analyse`
-      var (str): `The name of the var to retrieve`
+    Args:
+        code (str): `The code to analyse`
+        var (str): `The name of the var to retrieve`
 
-  Returns:
-      Any: `The value of the var`
-  """
+    Returns:
+        Any: `The value of the var`
+    """
 
-  return getVar(code, var).value
+    return getVar(code, var).value
+
 
 def getFuncCallArg(code: str, varname: str) -> str:
-  """
-  Get a arg from a function call example:
-  ```
-  code = '''key = base64.b64encode('Test')'''
-  print(getFuncCallArg(code, 'key')))
-  ```
-  `This will return 'Test'`
+    """
+    Get a arg from a function call example:
+    ```
+    code = '''key = base64.b64encode('Test')'''
+    print(getFuncCallArg(code, 'key')))
+    ```
+    `This will return 'Test'`
 
-  Args:
-      code (str): `The code to analyse`
-      varname (str): `The name of the var to retrieve`
+    Args:
+        code (str): `The code to analyse`
+        varname (str): `The name of the var to retrieve`
 
-  Returns:
-      str: `The arg of the func call`
-  """
-  
-  return getVar(code, varname).args[0].value
+    Returns:
+        str: `The arg of the func call`
+    """
+
+    return getVar(code, varname).args[0].value
+
 
 def AESDecrypt(key: bytes, iv: bytes, ciphertext: bytes) -> bytes:
-  """
-  Decrypt AES encrypter ciphertext
+    """
+    Decrypt AES encrypter ciphertext
 
-  Args:
-      key (bytes): `The secret key to use in the symmetric cipher.`
-      iv (bytes): `The initialization vector to use for encryption or decryption.`
-      ciphertext (bytes): `The piece of data to decrypt.`
+    Args:
+        key (bytes): `The secret key to use in the symmetric cipher.`
+        iv (bytes): `The initialization vector to use for encryption or decryption.`
+        ciphertext (bytes): `The piece of data to decrypt.`
 
-  Returns:
-      bytes: Decrypted Plain Text
-  """
-  cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
-  decrypted = cipher.decrypt(ciphertext)
-  return decrypted
+    Returns:
+        bytes: Decrypted Plain Text
+    """
+    cipher = AES.new(key, AES.MODE_GCM, nonce=iv)
+    decrypted = cipher.decrypt(ciphertext)
+    return decrypted
+
 
 def DetectObfuscator(code: bytes):
-  if isinstance(code, str):
-    code = code.encode()
-  
-  if b'___________' in code:
-    if findLZMA(code):
-      return 'BlankObf'
-  
-  return None
+    if isinstance(code, str):
+        code = code.encode()
+
+    if b'___________' in code:
+        if findLZMA(code):
+            return 'BlankObf'
+
+    return None
+
 
 def BlankObfV1(code: str) -> str:
-  """
-  Deobfuscate BlankObfV1 Plain Obfuscation
+    """
+    Deobfuscate BlankObfV1 Plain Obfuscation
 
-  Args:
-      code (str): `The code to deobfuscate`
+    Args:
+        code (str): `The code to deobfuscate`
 
-  Returns:
-      str: `The deobfuscated code`
-  """
-  ____ = getVarConst(code, '____')
-  _____ = getVarConst(code, '_____')
-  ______ = getVarConst(code, '______')
-  _______ = getVarConst(code, '_______')
-  deobfuscated = base64.b64decode(codecs.decode(____, 'rot13')+_____+______[::-1]+_______)
-  content = deobfuscated
-  return content
+    Returns:
+        str: `The deobfuscated code`
+    """
+    ____ = getVarConst(code, '____')
+    _____ = getVarConst(code, '_____')
+    ______ = getVarConst(code, '______')
+    _______ = getVarConst(code, '_______')
+    deobfuscated = base64.b64decode(codecs.decode(____, 'rot13') + _____ + ______[::-1] + _______)
+    content = deobfuscated
+    return content
+
 
 def mergeAdd(dict1: dict, dict2: dict) -> dict:
-  """
-  Merge 2 dict but add the already existing index instead of replacing
+    """
+    Merge 2 dict but add the already existing index instead of replacing
 
-  Args:
-      dict1 (dict): First dict
-      dict2 (dict): Second dict
+    Args:
+        dict1 (dict): First dict
+        dict2 (dict): Second dict
 
-  Returns:
-      dict: The merged dict
-  """
-  
-  result = dict1
-  
-  for i, v in dict2.items():
-    if result.get(i, False):
-      result[i] += v
-    else:
-      result[i] = v
-      
-  return result
+    Returns:
+        dict: The merged dict
+    """
+
+    result = dict1
+
+    for i, v in dict2.items():
+        if result.get(i, False):
+            result[i] += v
+        else:
+            result[i] = v
+
+    return result
+
 
 def findLZMA(content: bytes) -> bytes:
-  """
-  Find An Lzma Signature And Return The Decompressed Content
+    """
+    Find An Lzma Signature And Return The Decompressed Content
 
-  Args:
-      content (bytes): The Buffer To Search
+    Args:
+        content (bytes): The Buffer To Search
 
-  Returns:
-      bytes: The Decompressed LZMA
-  """
-  return lzma.decompress(LZMASign + content.split(LZMASign)[-1])
+    Returns:
+        bytes: The Decompressed LZMA
+    """
+    return lzma.decompress(LZMASign + content.split(LZMASign)[-1])
 
-def loadPyc(pyc: bytes, version: tuple[int, int]) -> tuple[xdis.Code3, tuple[int,int], bool, ModuleType]:
-  """
-  Load Pyc With Header Or Not
 
-  Args:
-      pyc (bytes): `The Target Pyc`
+def loadPyc(pyc: bytes, version: tuple[int, int]) -> tuple[xdis.Code3, tuple[int, int], bool, ModuleType]:
+    """
+    Load Pyc With Header Or Not
 
-  Returns:
-      tuple (xdis.codetype.CodeBase, tuple[int,int], bool, ModuleType): `A Tuple Of Info (CodeObj, VersionTuple, isPypy, OpCode)`
-  """
-  
-  if not isValidHeader(pyc):
+    Args:
+        pyc (bytes): `The Target Pyc`
 
-    pyc = setHeader(pyc, getHeader(version[1]))
-    
-  loaded = xdis.load_module_from_file_object(io.BytesIO(pyc))
-  
-  version_tuple = loaded[0]
-  code_obj = loaded[3]
-  ispypy = loaded[4]
-  opcode = xdis.get_opcode(version_tuple, ispypy)
-  
-  return (code_obj, version_tuple, ispypy, opcode)
+    Returns:
+        tuple (xdis.codetype.CodeBase, tuple[int,int], bool, ModuleType): `A Tuple Of Info (CodeObj, VersionTuple, isPypy, OpCode)`
+    """
+
+    if not isValidHeader(pyc):
+        pyc = setHeader(pyc, getHeader(version[1]))
+
+    loaded = xdis.load_module_from_file_object(io.BytesIO(pyc))
+
+    version_tuple = loaded[0]
+    code_obj = loaded[3]
+    ispypy = loaded[4]
+    opcode = xdis.get_opcode(version_tuple, ispypy)
+
+    return (code_obj, version_tuple, ispypy, opcode)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
             "ungrab=Ungrabber.cli:ungrab",
         ],
     },
-    install_requires=['xdis', 'cryptography', 'pycryptodome', 'yara-python', 'fernet'],
+    install_requires=['xdis', 'cryptography', 'pycryptodome', 'yara-python', 'fernet', 'httpx'],
     include_package_data=True,
     url='https://github.com/lululepu/Ungrabber',
     author='Lululepu',


### PR DESCRIPTION
### Summary

Only return list of webhooks that are valid. This can remove noise that returned by malformed malware configuration or purposely misleading payload.

*Notes: the large change is mainly caused by my pylint, let me know if you want me to keep the styling change or not.*

### Testing

Tested using this string:

```
https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ZZFILIAJsd\s\shttps://discord.com/api/webhooks/1359270846711201923/JR_FENYPDDnpPk3LHLfKJeYoOyPa0F4JA370_gZncLgKxTSuP0kZbFhRquEGEld4NanE
```

IDE Output:
```
Connected to pydev debugger (build 243.25659.43)
['https://discord.com/api/webhooks/1359270846711201923/JR_FENYPDDnpPk3LHLfKJeYoOyPa0F4JA370_gZncLgKxTSuP0kZbFhRquEGEld4NanE']

Process finished with exit code 0
```