### PR TITLE
Add rule to detect Behavior Stealer

### DIFF
--- a/Ungrabber/yara/rules.yar
+++ b/Ungrabber/yara/rules.yar
@@ -135,3 +135,15 @@ rule PlainBlankGrabber
   condition:
     all of them
 }
+
+rule BehaviorStealer
+{
+  meta:
+    description = "Detect Behavior Stealer"
+  
+  strings:
+    $a = "Behavior Stealer"
+  
+  condition:
+    $a
+}


### PR DESCRIPTION
This pull request adds a new YARA rule to the `Ungrabber/yara/rules.yar` file. The change introduces the `BehaviorStealer` rule to detect specific behavior patterns.

Detection enhancement:

* [`Ungrabber/yara/rules.yar`](diffhunk://#diff-1bc9206f790d75bed4274a9115a9e106d02433e9a4db5d2a2063a22d46f79d49R138-R149): Added the `BehaviorStealer` rule, including metadata, a string pattern `$a` for "Behavior Stealer," and a condition to match this pattern.